### PR TITLE
Made interactive mode reformat text passed in instead of treating it as a list of files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ flake8: _venv_3.8
 		xargs poetry run flake8 --max-line-length 88
 
 markflow: _venv_3.8
-	git ls-files | egrep ".md$$" | grep -v "/files/" | poetry run markflow --check
+	git ls-files | egrep ".md$$" | grep -v "/files/" | xargs poetry run markflow --check
 
 # --- TESTS ---
 .PHONY: tests


### PR DESCRIPTION
For whatever reason, I previously thought that black handled passing text to STDIN as a list of files. You can see in the Makefile that I clearly knew that wasn't the case since I use xargs to pass the list of files to it.