### PR TITLE
Have MarkFlow process content when ensuring dependencies are properly installed.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ _ensure_deps:
 	# Ensure dependencies markflow needs didn't sneak into dev dependencies
 	poetry env use ${PYTHON_VERSION}
 	poetry install --no-dev
-	poetry run markflow
+	echo -e "Hello\n--" | poetry run markflow
 	poetry install
 
 ensure_deps_3.6:


### PR DESCRIPTION
Though all imports should be caught, this is handy in case of imports in weird locations. That said, it doesn't catch everything, in fact only catching issues in heading processing, but I thought it would be nice to at least process some content.