### PR TITLE
Remove reinstallation of packages to speed up Github builds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,6 @@ _ensure_deps:
 	poetry env use ${PYTHON_VERSION}
 	poetry install --no-dev
 	poetry run markflow
-	poetry install
 
 ensure_deps_3.6:
 	PYTHON_VERSION=3.6 $(MAKE) _ensure_deps


### PR DESCRIPTION
I don't think it's a big deal to have to wait for reinstallation after running ensure deps locally, and the reinstallation of the packages in the build is just a waste of energy.