### PR TITLE
Bump release version to prepare for release of STDIN fix.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "markflow"
-version = "0.1.0"
+version = "0.1.1"
 description = "Make your Markdown Sparkle!"
 authors = ["Joshua Holland <jholland@duosecurity.com>"]
 


### PR DESCRIPTION
MarkFlow's current STDIN support where it treats it as a path is weird. We want to mainline this asap.