### PR TITLE
Handle semantic line breaks

### DIFF
--- a/markflow/detectors/paragraph.py
+++ b/markflow/detectors/paragraph.py
@@ -23,7 +23,8 @@ def paragraph_started(line: str, index: int, lines: List[str]) -> bool:
 
 def paragraph_ended(line: str, index: int, lines: List[str]) -> bool:
     return (
-        block_quote_started(line, index, lines)
+        ((index > 0) and lines[index - 1].endswith("  "))
+        or block_quote_started(line, index, lines)
         or tilda_code_block_started(line, index, lines)
         or heading_started(line, index, lines)
         or horizontal_line_started(line, index, lines)

--- a/markflow/formatters/paragraph.py
+++ b/markflow/formatters/paragraph.py
@@ -11,4 +11,7 @@ class MarkdownParagraph(MarkdownSection):
         self.lines.append(line)
 
     def reformatted(self, width: Number = 88) -> str:
-        return wrap(" ".join([line.strip() for line in self.lines]), width)
+        text = wrap(" ".join([line.strip() for line in self.lines]), width)
+        if self.lines[-1].endswith("  "):
+            text += "  "
+        return text

--- a/markflow/formatters/textwrap.py
+++ b/markflow/formatters/textwrap.py
@@ -249,6 +249,7 @@ def space_split(
 
 
 def wrap(text: str, width: Number) -> str:
+    # TODO: Should wrap be modifying the input. Maybe assert there's no newlines?
     lines = text.splitlines()
     text = " ".join([line.strip() for line in lines])
 

--- a/tests/files/0020_in_forced_paragraphs.md
+++ b/tests/files/0020_in_forced_paragraphs.md
@@ -1,0 +1,13 @@
+This is a paragraph  
+This is another 
+paragraph  
+
+This
+is
+all
+part
+of
+this
+paragraph
+but  
+this isn't

--- a/tests/files/0020_out_forced_paragraphs.md
+++ b/tests/files/0020_out_forced_paragraphs.md
@@ -1,0 +1,5 @@
+This is a paragraph  
+This is another paragraph  
+
+This is all part of this paragraph but  
+this isn't

--- a/tests/test_paragraph.py
+++ b/tests/test_paragraph.py
@@ -37,3 +37,16 @@ class TestParagraph:
         paragraph = create_section(MarkdownParagraph, expected)
         assert paragraph.reformatted() == expected
         assert render(expected) == render(input_)
+
+    def test_semantic_paragraph(self) -> None:
+        input_ = textwrap.dedent(
+            """\
+            Some words with a double
+            space after them.  """
+        )
+        expected = "Some words with a double space after them.  "
+        paragraph = create_section(MarkdownParagraph, input_)
+        assert paragraph.reformatted() == expected
+        paragraph = create_section(MarkdownParagraph, expected)
+        assert paragraph.reformatted() == expected
+        assert render(expected) == render(input_)


### PR DESCRIPTION
The Commonmark spec indicates that lines ending in double spaces indicate the end of a paragraph, even if text continues on the next line. This change supports that. This has been a long standing bug that I only recently understood the name of.