### PR TITLE
Fix paragraph detection (not an alignment submission) and as bonus fix logging

### DIFF
--- a/markflow/detectors/paragraph.py
+++ b/markflow/detectors/paragraph.py
@@ -32,7 +32,6 @@ def paragraph_ended(line: str, index: int, lines: List[str]) -> bool:
         or fenced_code_block_started(line, index, lines)
         or list_started(line, index, lines)
         or blank_line_started(line, index, lines)
-        or index + 1 == len(lines)
         # A setext heading cannot interrupt a paragraph (CommonMark 0.29 4.3)
         or thematic_break_started(line, index, lines)
     )

--- a/markflow/detectors/setext_heading.py
+++ b/markflow/detectors/setext_heading.py
@@ -76,9 +76,7 @@ def setext_heading_started(line: str, index: int, lines: List[str]) -> bool:
         if paragraph_ended(potential_line, potential_i, potential_lines):
             return False
 
-    return paragraph_ended(
-        potential_lines[-1], len(potential_lines) - 1, potential_lines
-    )
+    return True
 
 
 def setext_heading_ended(line: str, index: int, lines: List[str]) -> bool:

--- a/markflow/reformat_markdown.py
+++ b/markflow/reformat_markdown.py
@@ -161,7 +161,7 @@ def _reformat_markdown_text(
         if start == index:
             words = f"Line {start + 1}"
         else:
-            words = f"Lines {start + 1}-{index}"
+            words = f"Lines {start + 1}-{index+1}"
         logger.info("%s: %s", words, repr(sections[-1]))
 
     if sections and isinstance(sections[-1], MarkdownBlankLine):

--- a/tests/files/0007_out_link_reference_definitions.md
+++ b/tests/files/0007_out_link_reference_definitions.md
@@ -55,5 +55,4 @@ Paragraph
 
 [line_with_unclosed_title_at_end]
 
-[line_with_unclosed_title_at_end:
-/link 'Test
+[line_with_unclosed_title_at_end: /link 'Test


### PR DESCRIPTION
I noticed this when I was working on logging here. The real issue is that the logic in setext heading was putting too much of its logic into the paragraph detection logic.