### PR TITLE
Check indents instead of calling indented_code_block_started

### DIFF
--- a/markflow/_utils/__init__.py
+++ b/markflow/_utils/__init__.py
@@ -1,3 +1,3 @@
 # flake8: noqa
 import textwrap
-from ._utils import truncate_str
+from ._utils import *

--- a/markflow/_utils/_utils.py
+++ b/markflow/_utils/_utils.py
@@ -1,6 +1,14 @@
-__all__ = ["truncate_str"]
+__all__ = ["line_is_indented_at_least", "line_is_indented_less_than", "truncate_str"]
 
 ELLIPSIS = "..."
+
+
+def line_is_indented_less_than(line: str, count: int) -> bool:
+    return len(line) - len(line.lstrip()) < count
+
+
+def line_is_indented_at_least(line: str, count: int) -> bool:
+    return not line_is_indented_less_than(line, count)
 
 
 def truncate_str(str_: str, length: int) -> str:

--- a/markflow/detectors/atx_heading.py
+++ b/markflow/detectors/atx_heading.py
@@ -19,15 +19,16 @@ https://spec.commonmark.org/0.29/#atx-headings
 
 from typing import List
 
-from .indented_code_block import indented_code_block_started
+from .._utils import line_is_indented_at_least
 
 
 def atx_heading_started(line: str, index: int, lines: List[str]) -> bool:
+    if line_is_indented_at_least(line, 4):
+        return False
+
     # The standard says we must require a space, but it also notes that not everyone
     # follows this. Let's be lax and fix it for them in the formatter.
-    if line.lstrip().startswith("#") and not indented_code_block_started(
-        line, index, lines
-    ):
+    if line.lstrip().startswith("#"):
         return True
     else:
         return False

--- a/markflow/detectors/block_quote.py
+++ b/markflow/detectors/block_quote.py
@@ -1,14 +1,15 @@
 from typing import List
 
-from .indented_code_block import indented_code_block_started
 from .list import list_started
 from .blank_line import blank_line_started
+from .._utils import line_is_indented_at_least
 
 
 def block_quote_started(line: str, index: int, lines: List[str]) -> bool:
-    return not indented_code_block_started(
-        line, index, lines
-    ) and line.lstrip().startswith(">")
+    if line_is_indented_at_least(line, 4):
+        return False
+
+    return line.lstrip().startswith(">")
 
 
 def block_quote_ended(line: str, index: int, lines: List[str]) -> bool:

--- a/markflow/detectors/indented_code_block.py
+++ b/markflow/detectors/indented_code_block.py
@@ -18,14 +18,15 @@ https://spec.commonmark.org/0.29/#indented-code-blocks
 
 from typing import List
 
-INDENT = " " * 4
+from .._utils import line_is_indented_at_least, line_is_indented_less_than
 
 
 def indented_code_block_started(line: str, index: int, lines: List[str]) -> bool:
-    return bool(line.strip()) and line.startswith(INDENT)
+    return bool(line.strip()) and line_is_indented_at_least(line, 4)
 
 
 def indented_code_block_ended(line: str, index: int, lines: List[str]) -> bool:
+    # TODO: This can be done without the conditional here
     if not line.strip():
         # If we find a blank line, we need to check and see if the next non-blank line
         # is not indented
@@ -33,13 +34,10 @@ def indented_code_block_ended(line: str, index: int, lines: List[str]) -> bool:
             # We've found a blank line
             if not line.strip():
                 continue
-            if line.startswith(INDENT):
-                return False
-            else:
-                return True
+            return line_is_indented_less_than(line, 4)
         else:
             return False
-    elif line.startswith(INDENT):
+    elif line_is_indented_at_least(line, 4):
         return False
     else:
         return True

--- a/markflow/detectors/link_reference_definition.py
+++ b/markflow/detectors/link_reference_definition.py
@@ -29,10 +29,11 @@ import re
 
 from typing import List
 
+from .._utils import line_is_indented_at_least
+
 logger = logging.getLogger(__name__)
 
 LINK_REFERENCE_DEFINITION_FIRST_ELEMENT_REGEX = re.compile(
-    r" {0,3}"  # Indent
     r"\["  # Open bracket
     r"[^\]]{1,999}"  # At least one and up to 999 characters as the name
     r"\]:"  # End bracket and colon
@@ -46,13 +47,16 @@ __END_INDEX = -1
 def link_reference_definition_started(line: str, index: int, lines: List[str]) -> bool:
     global __END_INDEX
     global __QUOTATION
+    if line_is_indented_at_least(line, 4):
+        return False
 
-    match = LINK_REFERENCE_DEFINITION_FIRST_ELEMENT_REGEX.match(line)
+    rest_of_line = line.lstrip()
+    match = LINK_REFERENCE_DEFINITION_FIRST_ELEMENT_REGEX.match(rest_of_line)
     if not match:
         return False
 
     # We've already validated that the first word is the link definition
-    rest_of_line = line[match.end() :]
+    rest_of_line = rest_of_line[match.end() :]
     url_and_title = rest_of_line.split(maxsplit=1)
     # At the end of this, index is set to the line with the beginning of the title and
     # rest of line contains the title whether, even if it is the entire line. If there

--- a/markflow/detectors/paragraph.py
+++ b/markflow/detectors/paragraph.py
@@ -4,19 +4,21 @@ from .atx_heading import atx_heading_started
 from .blank_line import blank_line_started
 from .block_quote import block_quote_started
 from .fenced_code_block import fenced_code_block_started
-from .indented_code_block import indented_code_block_started
 from .list import list_started
 from .table import table_started
 from .thematic_break import thematic_break_started
+from .._utils import line_is_indented_at_least
 
 
 def paragraph_started(line: str, index: int, lines: List[str]) -> bool:
+    if line_is_indented_at_least(line, 4):
+        return False
+
     return not (
         atx_heading_started(line, index, lines)
         or blank_line_started(line, index, lines)
         or block_quote_started(line, index, lines)
         or fenced_code_block_started(line, index, lines)
-        or indented_code_block_started(line, index, lines)
         or list_started(line, index, lines)
         # A setext heading is just a paragraph with a line of - or = after
         or table_started(line, index, lines)

--- a/markflow/detectors/setext_heading.py
+++ b/markflow/detectors/setext_heading.py
@@ -26,9 +26,9 @@ https://spec.commonmark.org/0.29/#setext-headings
 
 from typing import List
 
-from .indented_code_block import indented_code_block_started
 from .list import list_started
 from .paragraph import paragraph_started, paragraph_ended
+from .._utils import line_is_indented_at_least
 
 
 def _is_underline(str_: str) -> bool:
@@ -41,9 +41,7 @@ def setext_heading_started(line: str, index: int, lines: List[str]) -> bool:
     if list_started(line, index, lines):
         # Lists can't be headings
         return False
-    elif indented_code_block_started(line, index, lines):
-        # TODO: This should likely detect more than three spaces of indentation instead
-        #  of code block.
+    elif line_is_indented_at_least(line, 4):
         return False
 
     # Avoid looking beyond the end of the file. This is clearly not a setext heading at
@@ -68,6 +66,7 @@ def setext_heading_started(line: str, index: int, lines: List[str]) -> bool:
         return False
 
     # TODO: Change when detectors are classes or something more reasonable
+    # TODO: It is also likely everything before potential_lines is unnecessary.
     if not paragraph_started(potential_lines[0], 0, potential_lines):
         return False
     for potential_i, potential_line in enumerate(potential_lines):

--- a/markflow/detectors/thematic_break.py
+++ b/markflow/detectors/thematic_break.py
@@ -19,19 +19,17 @@ https://spec.commonmark.org/0.29/#thematic-breaks
 
 from typing import List
 
-from .indented_code_block import indented_code_block_started
+from .._utils import line_is_indented_at_least
 
 SEPARATOR_SYMBOLS = ["*", "_", "-"]
 
 
 def thematic_break_started(line: str, index: int, lines: List[str]) -> bool:
-    spaceless_line = "".join(line.split())
-    if indented_code_block_started(line, index, lines):
-        # A line consisting of more than four spaces of indentation
-        # TODO: Should we move that to an explicit call instead of depending on the
-        #  indented code block code. Probably.
+    if line_is_indented_at_least(line, 4):
         return False
-    elif len(spaceless_line) < 3:
+
+    spaceless_line = "".join(line.split())
+    if len(spaceless_line) < 3:
         # Thematic breaks must be at least three characters long
         return False
     else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,10 @@
 import textwrap
 
-from markflow._utils._utils import truncate_str
+from markflow._utils._utils import (
+    line_is_indented_at_least,
+    line_is_indented_less_than,
+    truncate_str,
+)
 from markflow._utils.textwrap import (
     code_split,
     link_split,
@@ -22,6 +26,16 @@ class TestTruncateStr:
 
     def test_truncate_less_than_ellipsis(self) -> None:
         assert truncate_str("123456789", 2) == ".."
+
+
+class TestIndentChecks:
+    def test_is_indented_at_least(self) -> None:
+        assert line_is_indented_at_least("  Test", 2)
+        assert not line_is_indented_at_least("  Test", 3)
+
+    def test_is_indented_less_than(self) -> None:
+        assert not line_is_indented_less_than("  Test", 2)
+        assert line_is_indented_less_than("  Test", 3)
 
 
 class TestTextWrap:


### PR DESCRIPTION
This decouples several of the detectors from the indented code block detection. I also noticed a couple of places we could improve and removed an empty file.