### PR TITLE
Parsing functions now own text separation

### DIFF
--- a/markflow/_utils/_utils.py
+++ b/markflow/_utils/_utils.py
@@ -1,14 +1,13 @@
-__all__ = ["line_is_indented_at_least", "line_is_indented_less_than", "truncate_str"]
+__all__ = [
+    "get_indent",
+    "truncate_str",
+]
 
 ELLIPSIS = "..."
 
 
-def line_is_indented_less_than(line: str, count: int) -> bool:
-    return len(line) - len(line.lstrip()) < count
-
-
-def line_is_indented_at_least(line: str, count: int) -> bool:
-    return not line_is_indented_less_than(line, count)
+def get_indent(line: str) -> int:
+    return len(line) - len(line.lstrip())
 
 
 def truncate_str(str_: str, length: int) -> str:

--- a/markflow/detectors/atx_heading.py
+++ b/markflow/detectors/atx_heading.py
@@ -17,13 +17,30 @@ space. However, the space was required by the original ATX implementation.
 https://spec.commonmark.org/0.29/#atx-headings
 """
 
-from typing import List
+from typing import List, Tuple
 
-from .._utils import line_is_indented_at_least
+from .._utils import get_indent
+
+
+def split_atx_heading(
+    lines: List[str], line_offset: int = 0
+) -> Tuple[List[str], List[str]]:
+    atx_headings = []
+    remaining_lines = lines
+
+    if get_indent(lines[0]) >= 4:
+        pass
+    elif lines[0].lstrip().startswith("#"):
+        atx_headings = [lines[0]]
+        remaining_lines = lines[1:]
+    else:
+        pass
+
+    return atx_headings, remaining_lines
 
 
 def atx_heading_started(line: str, index: int, lines: List[str]) -> bool:
-    if line_is_indented_at_least(line, 4):
+    if get_indent(line) >= 4:
         return False
 
     # The standard says we must require a space, but it also notes that not everyone

--- a/markflow/detectors/blank_line.py
+++ b/markflow/detectors/blank_line.py
@@ -9,7 +9,7 @@ Blank lines at the beginning and end of the document are also ignored.
 https://spec.commonmark.org/0.29/#blank-lines
 """
 
-from typing import List
+from typing import List, Tuple
 
 
 def blank_line_started(line: str, index: int, lines: List[str]) -> bool:
@@ -18,3 +18,16 @@ def blank_line_started(line: str, index: int, lines: List[str]) -> bool:
 
 def blank_line_ended(line: str, index: int, lines: List[str]) -> bool:
     return True
+
+
+def split_blank_line(
+    lines: List[str], line_offset: int = 0
+) -> Tuple[List[str], List[str]]:
+    blank_line = []
+    remaining_lines = lines
+
+    if not lines[0].strip():
+        blank_line = [lines[0]]
+        remaining_lines = lines[1:]
+
+    return blank_line, remaining_lines

--- a/markflow/detectors/block_quote.py
+++ b/markflow/detectors/block_quote.py
@@ -1,12 +1,12 @@
-from typing import List
+from typing import List, Tuple
 
 from .list import list_started
 from .blank_line import blank_line_started
-from .._utils import line_is_indented_at_least
+from .._utils import get_indent
 
 
 def block_quote_started(line: str, index: int, lines: List[str]) -> bool:
-    if line_is_indented_at_least(line, 4):
+    if get_indent(line) >= 4:
         return False
 
     return line.lstrip().startswith(">")
@@ -14,3 +14,23 @@ def block_quote_started(line: str, index: int, lines: List[str]) -> bool:
 
 def block_quote_ended(line: str, index: int, lines: List[str]) -> bool:
     return blank_line_started(line, index, lines) or list_started(line, index, lines)
+
+
+def split_block_quote(
+    lines: List[str], line_offset: int = 0
+) -> Tuple[List[str], List[str]]:
+    block_quote = []
+    remaining_lines = lines
+
+    index = 0
+    if block_quote_started(lines[index], index, lines):
+        block_quote.append(lines[index])
+        for index, line in enumerate(lines[1:], start=index + 1):
+            if block_quote_ended(line, index, lines):
+                break
+            block_quote.append(line)
+        else:
+            index += 1
+    remaining_lines = lines[index:]
+
+    return block_quote, remaining_lines

--- a/markflow/detectors/list.py
+++ b/markflow/detectors/list.py
@@ -1,6 +1,6 @@
 import re
 
-from typing import List
+from typing import List, Tuple
 
 from .blank_line import blank_line_started
 from .table import table_started
@@ -27,3 +27,21 @@ def list_ended(line: str, index: int, lines: List[str]) -> bool:
         or table_started(line, index, lines)
         or thematic_break_started(line, index, lines)
     )
+
+
+def split_list(lines: List[str], line_offset: int = 0) -> Tuple[List[str], List[str]]:
+    list_ = []
+    remaining_lines = lines
+
+    index = 0
+    if list_started(lines[index], index, lines):
+        list_.append(lines[index])
+        for index, line in enumerate(lines[1:], start=index + 1):
+            if list_ended(line, index, lines):
+                break
+            list_.append(line)
+        else:
+            index += 1
+    remaining_lines = lines[index:]
+
+    return list_, remaining_lines

--- a/markflow/detectors/paragraph.py
+++ b/markflow/detectors/paragraph.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 from .atx_heading import atx_heading_started
 from .blank_line import blank_line_started
@@ -7,11 +7,11 @@ from .fenced_code_block import fenced_code_block_started
 from .list import list_started
 from .table import table_started
 from .thematic_break import thematic_break_started
-from .._utils import line_is_indented_at_least
+from .._utils import get_indent
 
 
 def paragraph_started(line: str, index: int, lines: List[str]) -> bool:
-    if line_is_indented_at_least(line, 4):
+    if get_indent(line) >= 4:
         return False
 
     return not (
@@ -35,5 +35,27 @@ def paragraph_ended(line: str, index: int, lines: List[str]) -> bool:
         or list_started(line, index, lines)
         or blank_line_started(line, index, lines)
         # A setext heading cannot interrupt a paragraph (CommonMark 0.29 4.3)
+        # ToDo: setext and paragraphs should call a common function and switch on this.
         or thematic_break_started(line, index, lines)
     )
+
+
+def split_paragraph(
+    lines: List[str], line_offset: int = 0
+) -> Tuple[List[str], List[str]]:
+    paragraph = []
+    remaining_lines = lines
+
+    index = 0
+    if paragraph_started(lines[index], index, lines):
+        paragraph.append(lines[index])
+        index = index + 1
+        for index, line in enumerate(lines[1:], start=index):
+            if paragraph_ended(line, index, lines):
+                break
+            paragraph.append(line)
+        else:
+            index += 1
+    remaining_lines = lines[index:]
+
+    return paragraph, remaining_lines

--- a/markflow/detectors/table.py
+++ b/markflow/detectors/table.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 
 def table_started(line: str, index: int, lines: List[str]) -> bool:
@@ -7,3 +7,21 @@ def table_started(line: str, index: int, lines: List[str]) -> bool:
 
 def table_ended(line: str, index: int, lines: List[str]) -> bool:
     return not table_started(line, index, lines)
+
+
+def split_table(lines: List[str], line_offset: int = 0) -> Tuple[List[str], List[str]]:
+    table = []
+    remaining_lines = lines
+
+    index = 0
+    if table_started(lines[index], index, lines):
+        table.append(lines[index])
+        for index, line in enumerate(lines[1:], start=index + 1):
+            if table_ended(line, index, lines):
+                break
+            table.append(line)
+        else:
+            index += 1
+    remaining_lines = lines[index:]
+
+    return table, remaining_lines

--- a/markflow/detectors/thematic_break.py
+++ b/markflow/detectors/thematic_break.py
@@ -17,15 +17,15 @@ If you want a thematic break in a list item, use a different bullet.
 https://spec.commonmark.org/0.29/#thematic-breaks
 """
 
-from typing import List
+from typing import List, Tuple
 
-from .._utils import line_is_indented_at_least
+from .._utils import get_indent
 
 SEPARATOR_SYMBOLS = ["*", "_", "-"]
 
 
 def thematic_break_started(line: str, index: int, lines: List[str]) -> bool:
-    if line_is_indented_at_least(line, 4):
+    if get_indent(line) >= 4:
         return False
 
     spaceless_line = "".join(line.split())
@@ -41,3 +41,25 @@ def thematic_break_started(line: str, index: int, lines: List[str]) -> bool:
 
 def thematic_break_ended(line: str, index: int, lines: List[str]) -> bool:
     return True
+
+
+def split_thematic_break(
+    lines: List[str], line_offset: int = 0
+) -> Tuple[List[str], List[str]]:
+    thematic_break = []
+    remaining_lines = lines
+
+    spaceless_line = "".join(lines[0].split())
+
+    if get_indent(lines[0]) > 4:
+        pass
+    elif len(spaceless_line) < 3:
+        # Thematic breaks must be at least three characters long
+        pass
+    else:
+        for symbol in SEPARATOR_SYMBOLS:
+            if all(char == symbol for char in spaceless_line.strip()):
+                thematic_break.append(lines[0])
+                remaining_lines = lines[1:]
+
+    return thematic_break, remaining_lines

--- a/markflow/formatters/base.py
+++ b/markflow/formatters/base.py
@@ -1,19 +1,17 @@
 import abc
 
-from typing import List
+from typing import List, Optional
 from ..typing import Number
 
 __all__ = ["MarkdownSection"]
 
 
 class MarkdownSection:
-    def __init__(self, line_index: int):
+    def __init__(self, line_index: int, lines: Optional[List[str]] = None):
         self.line_index = line_index
-        self.lines: List[str] = []
-
-    @abc.abstractmethod
-    def append(self, line: str) -> None:
-        """Append a line to this section"""
+        if lines is None:
+            lines = []
+        self.lines: List[str] = lines
 
     @abc.abstractmethod
     def reformatted(self, width: Number = 88) -> str:

--- a/markflow/reformat_markdown.py
+++ b/markflow/reformat_markdown.py
@@ -98,9 +98,7 @@ def _reformat_markdown_text(log_text: str, width: Number = 88) -> str:
                 else:
                     log_text = f"Line {current_line}"
                 logger.debug(
-                    "%s type: %s",
-                    log_text,
-                    section_type.value,
+                    "%s type: %s", log_text, section_type.value,
                 )
                 sections.append((section_type, section_content))
                 current_line += len(section_content)
@@ -118,9 +116,7 @@ def _reformat_markdown_text(log_text: str, width: Number = 88) -> str:
         formatter = FORMATTERS[section_type](offset, section_content)
         content_length = len(section_content)
         if content_length > 1:
-            log_text = (
-                f"Lines {offset + 1}-{offset + content_length}"
-            )
+            log_text = f"Lines {offset + 1}-{offset + content_length}"
         else:
             log_text = f"Line {offset + 1}"
         logger.info(f"%s: %s", log_text, repr(formatter))

--- a/markflow/typing.py
+++ b/markflow/typing.py
@@ -1,4 +1,16 @@
-from typing import Callable, List, Union
+from typing import Callable, List, Tuple, Union
+try:
+    from typing import Protocol
+except ImportError:
+    # Python <3.8
+    from typing_extensions import Protocol
 
 Number = Union[int, float]
 SectionEndedFunc = Callable[[str, int, List[str]], bool]
+
+
+class SplitFunc(Protocol):
+    def __call__(
+        self, lines: List[str], line_offset: int = 0
+    ) -> Tuple[List[str], List[str]]:
+        pass

--- a/markflow/typing.py
+++ b/markflow/typing.py
@@ -1,4 +1,5 @@
 from typing import Callable, List, Tuple, Union
+
 try:
     from typing import Protocol
 except ImportError:

--- a/markflow/typing.py
+++ b/markflow/typing.py
@@ -3,7 +3,7 @@ try:
     from typing import Protocol
 except ImportError:
     # Python <3.8
-    from typing_extensions import Protocol
+    from typing_extensions import Protocol  # type: ignore
 
 Number = Union[int, float]
 SectionEndedFunc = Callable[[str, int, List[str]], bool]

--- a/tests/files/0007_out_link_reference_definitions.md
+++ b/tests/files/0007_out_link_reference_definitions.md
@@ -42,8 +42,7 @@ wouldn\'t believe'
 wouldn\'t believe'
 
 [link_with_a_trailing_paragraph]: /link
-'Paragraph after this' Paragraph'
-Paragraph
+'Paragraph after this' Paragraph' Paragraph
 
 [link with space]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,7 @@
 import textwrap
 
 from markflow._utils._utils import (
-    line_is_indented_at_least,
-    line_is_indented_less_than,
+    get_indent,
     truncate_str,
 )
 from markflow._utils.textwrap import (
@@ -28,14 +27,11 @@ class TestTruncateStr:
         assert truncate_str("123456789", 2) == ".."
 
 
-class TestIndentChecks:
+class TestGetIndent:
     def test_is_indented_at_least(self) -> None:
-        assert line_is_indented_at_least("  Test", 2)
-        assert not line_is_indented_at_least("  Test", 3)
-
-    def test_is_indented_less_than(self) -> None:
-        assert not line_is_indented_less_than("  Test", 2)
-        assert line_is_indented_less_than("  Test", 3)
+        # This is a little silly, but I expect we may have more cases to support since
+        # we currently conflate tabs and spaces.
+        assert get_indent("  Test") == 2
 
 
 class TestTextWrap:

--- a/tests/util.py
+++ b/tests/util.py
@@ -12,9 +12,7 @@ LIST_NUMBERING_START = re.compile(r" start=\"[0-9]+\"")
 
 
 def create_section(class_: Type[MarkdownSection], text: str) -> MarkdownSection:
-    obj = class_(0)
-    for line in text.splitlines():
-        obj.append(line)
+    obj = class_(0, text.splitlines())
     return obj
 
 


### PR DESCRIPTION
Instead of having a state machine manage what line we're and what we're processing, instead, our new functions take in the entirety of the text we are trying to process, and pop off their portion if the text starts with that section. This gets rid of the need for global variables and will eventually make more of the code readable. This is occurring halfway through standard alignment, so it's a bit dirty, but was necessary to start working on leaf blocks.

This also fixed an undetected issue with badly formatted link reference definition reformatting.