### PR TITLE
Ensure paragraph splitting conforms to the CommonMark standard

### DIFF
--- a/markflow/detectors/_lines.py
+++ b/markflow/detectors/_lines.py
@@ -112,7 +112,7 @@ def is_indented_code_block_start_line(line: str) -> bool:
     Returns:
         True if the line is could start an indented code block. False otherwise.
     """
-    return line.strip() and get_indent(line) >= 4
+    return bool(line.strip()) and get_indent(line) >= 4
 
 
 def is_list_start_line(line: str) -> bool:

--- a/markflow/detectors/_lines.py
+++ b/markflow/detectors/_lines.py
@@ -1,0 +1,226 @@
+"""
+MarkFlow Line Detection Library
+
+This library is used a common space to evaluate position independent information about
+lines. They are stored here so as to avoid any circular imports.
+"""
+
+import re
+
+from .._utils import get_indent
+
+FENCED_CODE_BLOCK_FENCE_CHARACTERS = ["`", "~"]
+LIST_START_REGEX = re.compile(
+    r"^\s*"  # Leading spaces are OK and often expected
+    r"("
+    r"\*|"  # Asterisk list marker
+    r"-|"  # Dash list marker
+    r"\+|"  # Plust list marker
+    r"[0-9]+\."  # Numeric list marker
+    r") "  # Lists need a space after their identifier
+)
+THEMATIC_BREAK_CHARACTERS = ["*", "_", "-"]
+
+
+def is_atx_heading_line(line: str) -> bool:
+    """Evaluates whether a line is formatted like an ATX heading
+
+    The standard requires a space, but it also notes that not everyone follows this. We
+    are lax in our definition and fix it on reformatting.
+
+    Examples:
+        ```
+        #Heading
+        # Heading
+        ```
+
+    Args:
+        line: The line to evaluate
+
+    Returns:
+        True if the line is an ATX heading. False otherwise.
+    """
+    return not is_indented_code_block_start_line(line) and line.lstrip().startswith("#")
+
+
+def is_blank_line_line(line: str) -> bool:
+    """Evaluates whether a line is a blank line
+
+    Example:
+        ```
+
+        ```
+
+    Args:
+        line: The line to evaluate
+
+    Returns:
+        True if the line is an ATX heading. False otherwise.
+    """
+    return not line.strip()
+
+
+def is_block_quote_line(line: str) -> bool:
+    """Evaluates whether a line is a block quote line
+
+    Example:
+        ```
+        > Block Quote
+        ```
+
+    Args:
+        line: The line to evaluate
+
+    Returns:
+        True if the line is an block quote line. False otherwise.
+    """
+    return not is_indented_code_block_start_line(line) and line.lstrip().startswith(">")
+
+
+def is_fenced_code_block_start_line(line: str) -> bool:
+    """Evaluates whether a line could open a fenced code block
+
+    Examples:
+        ```
+        ```python3
+        ~~~markdown
+        ```
+
+    Args:
+        line: The line to evaluate
+
+    Returns:
+        True if the line is could open a fenced code block. False otherwise.
+    """
+    for fence in FENCED_CODE_BLOCK_FENCE_CHARACTERS:
+        if line.strip().startswith(fence * 3):
+            return True
+    return False
+
+
+def is_indented_code_block_start_line(line: str) -> bool:
+    """Evaluates whether a line could start and indented code block
+
+    Examples:
+        ```
+            There's four spaces before this
+        ```
+
+    Args:
+        line: The line to evaluate
+
+    Returns:
+        True if the line is could start an indented code block. False otherwise.
+    """
+    return line.strip() and get_indent(line) >= 4
+
+
+def is_list_start_line(line: str) -> bool:
+    """Evaluates whether a line could start a list
+
+    Examples:
+        ```
+        * Unordered List
+        1. Ordered List
+        ```
+
+    Args:
+        line: The line to evaluate
+
+    Returns:
+        True if the line is could start a list. False otherwise.
+    """
+    return not is_indented_code_block_start_line(line) and bool(
+        LIST_START_REGEX.search(line)
+    )
+
+
+def is_paragraph_start_line(line: str) -> bool:
+    """Evaluates whether a line could start a paragraph
+
+    We basically evaluate that no other section type could start instead.
+
+    Examples:
+        ```
+        Just some text
+        ```
+
+    Args:
+        line: The line to evaluate
+
+    Returns:
+        True if the line is could start a list. False otherwise.
+    """
+    for line_checker in [
+        is_indented_code_block_start_line,
+        is_atx_heading_line,
+        is_blank_line_line,
+        is_block_quote_line,
+        is_fenced_code_block_start_line,
+        is_list_start_line,
+        is_table_start_line,
+        is_thematic_break_line,
+    ]:
+        if line_checker(line):
+            return False
+    return True
+
+
+def is_setext_underline(line: str) -> bool:
+    """Evaluates whether a line could be the underlining for a setext heading
+
+    Examples:
+        ```
+        ---
+          ==
+        ```
+
+    Args:
+        line: The line to evaluate
+
+    Returns:
+        True if the line is could underline an setext heading. False otherwise.
+    """
+    return (
+        not is_indented_code_block_start_line(line)
+        and bool(line.strip())
+        and (
+            all([c == "=" for c in line.strip()])
+            or all([c == "-" for c in line.strip()])
+        )
+    )
+
+
+def is_table_start_line(line: str) -> bool:
+    """Evaluates whether a line could start a table
+
+    Examples:
+        ```
+        |Table|
+        ```
+
+    Args:
+        line: The line to evaluate
+
+    Returns:
+        True if the line is could start a table. False otherwise.
+    """
+    # ToDo: Not really, but we'll have to adapt a standard from somewhere other than
+    #  CommonMark
+    return line.lstrip().startswith("|")
+
+
+def is_thematic_break_line(line: str) -> bool:
+    if is_indented_code_block_start_line(line):
+        return False
+
+    spaceless_line = "".join(line.split())
+    if len(spaceless_line) < 3:
+        # Thematic breaks must be at least three characters long
+        return False
+    else:
+        for symbol in THEMATIC_BREAK_CHARACTERS:
+            if all(char == symbol for char in spaceless_line.strip()):
+                return True
+        else:
+            return False

--- a/markflow/detectors/atx_heading.py
+++ b/markflow/detectors/atx_heading.py
@@ -20,7 +20,6 @@ Examples:
 from typing import List, Tuple
 
 from ._lines import is_atx_heading_line
-from .._utils import get_indent
 
 
 def split_atx_heading(

--- a/markflow/detectors/atx_heading.py
+++ b/markflow/detectors/atx_heading.py
@@ -19,6 +19,7 @@ Examples:
 
 from typing import List, Tuple
 
+from ._lines import is_atx_heading_line
 from .._utils import get_indent
 
 
@@ -41,36 +42,7 @@ def split_atx_heading(
         otherwise it is `None`. The second value is the remaining text. (If lines does
         not start with an ATX heading, it is the same as lines.)
     """
-    atx_headings = []
-    remaining_lines = lines
-
-    if get_indent(lines[0]) >= 4:
-        pass
-    elif lines[0].lstrip().startswith("#"):
-        # The standard says we must require a space, but it also notes that not everyone
-        # follows this. Let's be lax and fix it for them in the formatter.
-        # ToDo: warn?
-        atx_headings = [lines[0]]
-        remaining_lines = lines[1:]
+    if is_atx_heading_line(lines[0]):
+        return [lines[0]], lines[1:]
     else:
-        pass
-
-    return atx_headings, remaining_lines
-
-
-def atx_heading_started(line: str, index: int, lines: List[str]) -> bool:
-    """DEPRECATED"""
-    if get_indent(line) >= 4:
-        return False
-
-    # The standard says we must require a space, but it also notes that not everyone
-    # follows this. Let's be lax and fix it for them in the formatter.
-    if line.lstrip().startswith("#"):
-        return True
-    else:
-        return False
-
-
-def atx_heading_ended(line: str, index: int, lines: List[str]) -> bool:
-    """DEPRECATED"""
-    return True
+        return [], lines

--- a/markflow/detectors/blank_line.py
+++ b/markflow/detectors/blank_line.py
@@ -12,15 +12,7 @@ Example:
 
 from typing import List, Tuple
 
-
-def blank_line_started(line: str, index: int, lines: List[str]) -> bool:
-    """DEPRECATED"""
-    return not line.strip()
-
-
-def blank_line_ended(line: str, index: int, lines: List[str]) -> bool:
-    """DEPRECATED"""
-    return True
+from ._lines import is_blank_line_line
 
 
 def split_blank_line(
@@ -38,11 +30,7 @@ def split_blank_line(
         single-element list), otherwise it is `None`. The second value is the remaining
         text. (If lines does not start with a blank line, it is the same as lines.)
     """
-    blank_line = []
-    remaining_lines = lines
-
-    if not lines[0].strip():
-        blank_line = [lines[0]]
-        remaining_lines = lines[1:]
-
-    return blank_line, remaining_lines
+    if is_blank_line_line(lines[0]):
+        return [lines[0]], lines[1:]
+    else:
+        return [], lines

--- a/markflow/detectors/block_quote.py
+++ b/markflow/detectors/block_quote.py
@@ -1,21 +1,17 @@
 from typing import List, Tuple
 
-from .list import list_started
-from .blank_line import blank_line_started
-from .._utils import get_indent
+from ._lines import is_block_quote_line
+from ._lines import is_list_start_line, is_blank_line_line
 
 
 def block_quote_started(line: str, index: int, lines: List[str]) -> bool:
     """DEPRECATED"""
-    if get_indent(line) >= 4:
-        return False
-
-    return line.lstrip().startswith(">")
+    return is_block_quote_line(line)
 
 
 def block_quote_ended(line: str, index: int, lines: List[str]) -> bool:
     """DEPRECATED"""
-    return blank_line_started(line, index, lines) or list_started(line, index, lines)
+    return is_blank_line_line(line) or is_list_start_line(line)
 
 
 def split_block_quote(

--- a/markflow/detectors/list.py
+++ b/markflow/detectors/list.py
@@ -1,34 +1,24 @@
-import re
-
 from typing import List, Tuple
 
-from .blank_line import blank_line_started
-from .table import table_started
-from .thematic_break import thematic_break_started
-
-
-LIST_REGEX = re.compile(
-    r"^\s*"  # Leading spaces are OK and often expected
-    r"("
-    r"\*|"  # Asterisk list marker
-    r"-|"  # Dash list marker
-    r"\+|"  # Plus list marker
-    r"[0-9]+\."  # Numeric list marker
-    r") "  # Lists need a space after their identifier
+from ._lines import (
+    is_blank_line_line,
+    is_list_start_line,
+    is_table_start_line,
+    is_thematic_break_line,
 )
 
 
 def list_started(line: str, index: int, lines: List[str]) -> bool:
     """DEPRECATED"""
-    return bool(LIST_REGEX.search(line))
+    return is_list_start_line(line)
 
 
 def list_ended(line: str, index: int, lines: List[str]) -> bool:
     """DEPRECATED"""
     return (
-        blank_line_started(line, index, lines)
-        or table_started(line, index, lines)
-        or thematic_break_started(line, index, lines)
+        is_blank_line_line(line)
+        or is_table_start_line(line)
+        or is_thematic_break_line(line)
     )
 
 

--- a/markflow/detectors/paragraph.py
+++ b/markflow/detectors/paragraph.py
@@ -1,63 +1,134 @@
-from typing import List, Tuple
+from typing import List, Generator, Tuple
 
-from .atx_heading import atx_heading_started
-from .blank_line import blank_line_started
-from .block_quote import block_quote_started
-from .fenced_code_block import fenced_code_block_started
-from .list import list_started
-from .table import table_started
-from .thematic_break import thematic_break_started
-from .._utils import get_indent
+from ._lines import is_paragraph_start_line, is_setext_underline
+from .atx_heading import split_atx_heading
+from .blank_line import split_blank_line
+from .block_quote import split_block_quote
+from .fenced_code_block import split_fenced_code_block
+from .list import split_list
+from .table import split_table
+from .thematic_break import split_thematic_break
 
 
-def paragraph_started(line: str, index: int, lines: List[str]) -> bool:
-    """DEPRECATED"""
-    if get_indent(line) >= 4:
+def paragraph_continues(lines: List[str], line_offset: int = 0) -> bool:
+    """Indicates whether the first line of lines would continue a paragraph
+
+    This ensures that any valid interrupting section of a paragraph could not result in
+    a valid block instead.
+
+    Args:
+        lines: The lines to evaluate.
+        line_offset (optional): The offset into the overall document we are at. This is
+            used for reporting errors in the original document.
+
+    Returns:
+        True if the first line would continue the paragraph. False otherwise.
+    """
+    for splitter in [
+        split_atx_heading,
+        split_blank_line,
+        split_block_quote,
+        split_fenced_code_block,
+        split_list,
+        split_table,
+        split_thematic_break,
+    ]:
+        # ToDo: Disable logging?
+        if splitter(lines, line_offset)[0]:
+            return False
+    if is_setext_underline(lines[0]):
         return False
-
-    return not (
-        atx_heading_started(line, index, lines)
-        or blank_line_started(line, index, lines)
-        or block_quote_started(line, index, lines)
-        or fenced_code_block_started(line, index, lines)
-        or list_started(line, index, lines)
-        # A setext heading is just a paragraph with a line of - or = after
-        or table_started(line, index, lines)
-        or thematic_break_started(line, index, lines)
-    )
+    return True
 
 
-def paragraph_ended(line: str, index: int, lines: List[str]) -> bool:
-    """DEPRECATED"""
-    return (
-        ((index > 0) and lines[index - 1].endswith("  "))
-        or atx_heading_started(line, index, lines)
-        or block_quote_started(line, index, lines)
-        or fenced_code_block_started(line, index, lines)
-        or list_started(line, index, lines)
-        or blank_line_started(line, index, lines)
-        # A setext heading cannot interrupt a paragraph (CommonMark 0.29 4.3)
-        # ToDo: setext and paragraphs should call a common function and switch on this.
-        or thematic_break_started(line, index, lines)
-    )
+def list_tail_generator(lines: List[str]) -> Generator[List[str], None, None]:
+    """Generator that returns less and less of the end of a list
+
+    The first call to this generator returns the passed in list. Each successive call
+    to this generator returns the previous call without the first element until we
+    return the last element.
+
+    Args:
+        lines: The lines to evaluate
+        line_offset (optional): The offset into the overall document we are at. This is
+            used for reporting errors in the original document.
+
+    Returns:
+        A tuple of two values. The first is the setext heading lines if they were found,
+        otherwise it is an empty list. The second value is the remaining text. (If lines
+        does not start with a thematic break, it is the same as lines.)
+
+        The returned text can then be evaluated to determine if this is actually a
+        paragraph or an setext heading.
+    """
+    for i in range(len(lines)):
+        yield lines[i:]
+
+
+def split_paragraph_ignoring_setext(
+    lines: List[str], line_offset: int = 0
+) -> Tuple[List[str], List[str]]:
+    """Split a paragraph from beginning of lines if one exists
+
+    Unlike split_paragraph, this does not take into account setext underlining. This is
+    so that both detectors can share a common function.
+
+    Args:
+        lines: The lines to evaluate.
+        line_offset (optional): The offset into the overall document we are at. This is
+            used for reporting errors in the original document.
+
+    Returns:
+        A tuple of two values. The first is the paragraph lines if a paragraph was
+        found, otherwise it is an empty list. The second value is the remaining text.
+        (If lines does not start with a thematic break, it is the same as lines.)
+    """
+    paragraph_lines = []
+    remaining_lines = lines
+
+    if is_paragraph_start_line(lines[0]):
+        # ToDo: This should be handled in `wrap` as a double space is always a newline
+        #  in any section type. Also add indents while you're there.
+        if lines[0].endswith("  "):
+            return [lines[0]], lines[1:]
+        paragraph_lines.append(lines[0])
+        tail_lines_generator = list_tail_generator(lines[1:])
+        for tail in tail_lines_generator:
+            if paragraph_continues(tail, line_offset + len(paragraph_lines)):
+                paragraph_lines.append(tail[0])
+                # ToDo: This should be handled in `wrap` as a double space is always a
+                #  newline in any section type.
+                if tail[0].endswith("  "):
+                    remaining_lines = next(tail_lines_generator)
+                    break
+            else:
+                remaining_lines = tail
+                break
+        else:
+            remaining_lines = []
+
+    return paragraph_lines, remaining_lines
 
 
 def split_paragraph(
     lines: List[str], line_offset: int = 0
 ) -> Tuple[List[str], List[str]]:
-    paragraph = []
-    remaining_lines = lines
+    """Split a paragraph from beginning of lines if one exists
 
-    index = 0
-    if paragraph_started(lines[index], index, lines):
-        paragraph.append(lines[index])
-        index = index + 1
-        for index, line in enumerate(lines[1:], start=index):
-            if paragraph_ended(line, index, lines):
-                break
-            paragraph.append(line)
-        else:
-            index += 1
-    remaining_lines = lines[index:]
+    Args:
+        lines: The lines to evaluate.
+        line_offset (optional): The offset into the overall document we are at. This is
+            used for reporting errors in the original document.
 
-    return paragraph, remaining_lines
+    Returns:
+        A tuple of two values. The first is the paragraph lines if a paragraph was
+        found, otherwise it is an empty list. The second value is the remaining text.
+        (If lines does not start with a thematic break, it is the same as lines.)
+    """
+    potential_paragraph, remaining_lines = split_paragraph_ignoring_setext(
+        lines, line_offset
+    )
+    if not remaining_lines or not is_setext_underline(remaining_lines[0]):
+        return potential_paragraph, remaining_lines
+    else:
+        return [], lines

--- a/markflow/detectors/setext_heading.py
+++ b/markflow/detectors/setext_heading.py
@@ -19,82 +19,26 @@ Examples:
 
 from typing import List, Tuple
 
-from .list import list_started
-from .paragraph import paragraph_started, paragraph_ended
-from .._utils import get_indent
-
-
-def _is_underline(str_: str) -> bool:
-    return bool(str_.strip()) and (
-        all([c == "=" for c in str_.strip()]) or all([c == "-" for c in str_.strip()])
-    )
-
-
-def setext_heading_started(line: str, index: int, lines: List[str]) -> bool:
-    """DEPRECATED"""
-    if list_started(line, index, lines):
-        # Lists can't be headings
-        return False
-    elif get_indent(line) >= 4:
-        return False
-
-    # Avoid looking beyond the end of the file. This is clearly not a setext heading at
-    # that point.
-    if len(lines) <= index + 1:
-        return False
-
-    # Well an underline clearly isn't a title
-    if _is_underline(line):
-        return False
-
-    # We're basically checking if the lines up to the underlining could be a paragraph.
-    # We could also move to checking not this: code fence, ATX heading, block quote,
-    # thematic break, list item, or HTML block, though that may be more useful in the
-    # paragraph detector.
-    potential_lines = []
-    for potential_line in lines[index:]:
-        if _is_underline(potential_line):
-            break
-        potential_lines.append(potential_line)
-    else:
-        return False
-
-    # TODO: Change when detectors are classes or something more reasonable
-    # TODO: It is also likely everything before potential_lines is unnecessary.
-    if not paragraph_started(potential_lines[0], 0, potential_lines):
-        return False
-    for potential_i, potential_line in enumerate(potential_lines):
-        if potential_i == 0:
-            continue
-        if paragraph_ended(potential_line, potential_i, potential_lines):
-            return False
-
-    return True
-
-
-def setext_heading_ended(line: str, index: int, lines: List[str]) -> bool:
-    """DEPRECATED"""
-    return _is_underline(lines[index - 1])
+from ._lines import is_setext_underline
+from .paragraph import split_paragraph_ignoring_setext
 
 
 def split_setext_heading(
     lines: List[str], line_offset: int = 0
 ) -> Tuple[List[str], List[str]]:
-    # ToDo: Instead of using this pattern, leverage the unified `_paragraph_split` which
-    #  will provide a way to split out a paragraph, not caring if it is a setext or not.
-    #  `paragraph_split` will handle that for paragraphs.
-    setext_heading = []
-    remaining_lines = lines
+    """Split setext heading from beginning of lines if one exists
 
-    index = 0
-    if setext_heading_started(lines[index], index, lines):
-        setext_heading.append(lines[index])
-        for index, line in enumerate(lines[1:], start=index + 1):
-            if setext_heading_ended(line, index, lines):
-                break
-            setext_heading.append(line)
-        else:
-            index += 1
-    remaining_lines = lines[index:]
+    Args:
+        lines: The lines to evaluate.
+        line_offset (optional): The offset into the overall document we are at. This is
+            used for reporting errors in the original document.
 
-    return setext_heading, remaining_lines
+    Returns:
+        A tuple of two values. The first is the setext heading lines if they were found,
+        otherwise it is an empty list. The second value is the remaining text. (If lines
+        does not start with a thematic break, it is the same as lines.)
+    """
+    paragraph, remaining_lines = split_paragraph_ignoring_setext(lines, line_offset)
+    if paragraph and remaining_lines and is_setext_underline(remaining_lines[0]):
+        return paragraph + [remaining_lines[0]], remaining_lines[1:]
+    return [], lines

--- a/markflow/detectors/thematic_break.py
+++ b/markflow/detectors/thematic_break.py
@@ -17,30 +17,10 @@ Examples:
 
 from typing import List, Tuple
 
+from ._lines import is_thematic_break_line
 from .._utils import get_indent
 
 SEPARATOR_SYMBOLS = ["*", "_", "-"]
-
-
-def thematic_break_started(line: str, index: int, lines: List[str]) -> bool:
-    """DEPRECATED"""
-    if get_indent(line) >= 4:
-        return False
-
-    spaceless_line = "".join(line.split())
-    if len(spaceless_line) < 3:
-        # Thematic breaks must be at least three characters long
-        return False
-    else:
-        for symbol in SEPARATOR_SYMBOLS:
-            if all(char == symbol for char in spaceless_line.strip()):
-                return True
-        return False
-
-
-def thematic_break_ended(line: str, index: int, lines: List[str]) -> bool:
-    """DEPRECATED"""
-    return True
 
 
 def split_thematic_break(
@@ -58,20 +38,7 @@ def split_thematic_break(
         found, otherwise it is `None`. The second value is the remaining text. (If lines
         does not start with a thematic break, it is the same as lines.)
     """
-    thematic_break = []
-    remaining_lines = lines
-
-    spaceless_line = "".join(lines[0].split())
-
-    if get_indent(lines[0]) > 4:
-        pass
-    elif len(spaceless_line) < 3:
-        # Thematic breaks must be at least three characters long
-        pass
+    if is_thematic_break_line(lines[0]):
+        return [lines[0]], lines[1:]
     else:
-        for symbol in SEPARATOR_SYMBOLS:
-            if all(char == symbol for char in spaceless_line.strip()):
-                thematic_break.append(lines[0])
-                remaining_lines = lines[1:]
-
-    return thematic_break, remaining_lines
+        return [], lines

--- a/markflow/detectors/thematic_break.py
+++ b/markflow/detectors/thematic_break.py
@@ -18,7 +18,6 @@ Examples:
 from typing import List, Tuple
 
 from ._lines import is_thematic_break_line
-from .._utils import get_indent
 
 SEPARATOR_SYMBOLS = ["*", "_", "-"]
 

--- a/markflow/reformat_markdown.py
+++ b/markflow/reformat_markdown.py
@@ -83,6 +83,7 @@ FORMATTERS: Dict[MarkdownSectionEnum, Type[MarkdownSection]] = {
 
 
 def _reformat_markdown_text(log_text: str, width: Number = 88) -> str:
+    # TODO: Sanitize newlines
     remaining_lines = log_text.splitlines()
     sections = []
     current_line = 1
@@ -105,8 +106,9 @@ def _reformat_markdown_text(log_text: str, width: Number = 88) -> str:
                 break
         else:
             raise RuntimeError(
-                "Could not determine section type on line %d",
-                sum(len(content) for type, content in sections) + 1,
+                "Could not determine section type on line {}".format(
+                    sum(len(content) for type, content in sections) + 1
+                ),
             )
 
     formatters = []


### PR DESCRIPTION
This includes a major update that removes most of the old starting functions and implementing the todo from setext. I also noticed a small bug that was preventing me from debugging as well as another in wrapping. I'll be fixing those soon.