### PR TITLE
Make directory lookups recursive

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,8 @@ understand what that's doing, though, read on.
 
 All tools that are available in the poetery environment (including MarkFlow) can easily
 be added to you command line as the commands themselves by running
-`source poetry-aliases.sh`.
+`source poetry-aliases.sh`. An additional alias, `markflow-markflow`, is also provided
+to easily run MarkFlow only on non-test files.
 
 ### Running Audits
 

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ flake8: _venv_3.8
 		xargs poetry run flake8
 
 markflow: _venv_3.8
-	git ls-files | egrep ".md$$" | grep -v "/files/" | xargs poetry run markflow --check
+	git ls-files | egrep ".md$$" | grep -v "tests/" | xargs poetry run markflow --check
 
 # --- TESTS ---
 .PHONY: tests tests_3.6 tests_3.7 tests_3.8 tests_3.9

--- a/markflow/_argparse.py
+++ b/markflow/_argparse.py
@@ -123,7 +123,6 @@ class AddMarkdownFilesInDirOrPathsAction(argparse.Action):
             if value.is_file():
                 expanded_paths.append(value)
             else:
-                markdown_paths = glob.glob(str(value / "*.md"))
-                markdown_paths += glob.glob(str(value / "**" / "*.md"))
+                markdown_paths = glob.glob(str(value / "**" / "*.md"), recursive=True)
                 expanded_paths += [pathlib.Path(path) for path in markdown_paths]
         setattr(namespace, self.dest, expanded_paths)

--- a/poetry-aliases.sh
+++ b/poetry-aliases.sh
@@ -4,3 +4,6 @@ alias markflow="poetry run markflow"
 alias mypy="poetry run mypy"
 alias pytest="poetry run pytest"
 alias python="poetry run python"
+
+# Alias for running MarkFlow on our files that avoids clobbering out tests.
+alias markflow-markflow='git ls-files | egrep ".md\$\$" | grep -v "tests/" | xargs poetry run markflow --check'


### PR DESCRIPTION
This includes changes to ensure we only run MarkFlow audits on the correct files and provides an alias, `markflow-markflow` for running MarkFlow on non-test files.