### PR TITLE
Bump MarkFlow version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "markflow"
-version = "0.1.2"
+version = "0.1.3"
 description = "Make your Markdown Sparkle!"
 authors = ["Joshua Holland <jholland@duosecurity.com>"]
 


### PR DESCRIPTION
With the version flag added to MarkFlow, we'll keep the repo one version ahead of whatever is released. This makes it obvious even when doing testing on a build package that you are working with development.