### PR TITLE
Update packages to their latest versions, with an emphasis on audits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,11 @@ audits:
 		status=$$(($$status + $$?)); \
 		echo ""; \
 	done; \
+	if [ $$status -eq 0 ]; then \
+	    echo "All Audits Succeeded!"; \
+	else \
+		echo "Some audits failed. :("; \
+	fi; \
 	exit $$status
 
 black: _venv_3.8

--- a/markflow/__main__.py
+++ b/markflow/__main__.py
@@ -351,7 +351,7 @@ def _reformat_stdin(args: argparse.Namespace, stdin: TextIO) -> int:
 
     if args.check:
         if new_contents != old_contents:
-            print_markdown(f"STDIN would be reformatted.")
+            print_markdown("STDIN would be reformatted.")
             return 1
         else:
             print_markdown("STDIN would be unchanged.")

--- a/markflow/formatters/setext_heading.py
+++ b/markflow/formatters/setext_heading.py
@@ -49,14 +49,14 @@ class MarkdownSetextHeading(MarkdownSection):
             raise RuntimeError(
                 f"Attempted access of uninitialized {self.__class__.__name__}."
             )
-        return " ".join(l.strip() for l in self.lines[:-1])
+        return " ".join(line.strip() for line in self.lines[:-1])
 
     def append(self, line: str) -> None:
         self.lines.append(line)
 
     def reformatted(self, width: Number = 88) -> str:
         heading_str = wrap(self.content, width)
-        heading_len = max(len(l) for l in heading_str.splitlines())
+        heading_len = max(len(line) for line in heading_str.splitlines())
         return heading_str + "\n" + self.char * heading_len
 
     def __repr__(self) -> str:

--- a/markflow/reformat_markdown.py
+++ b/markflow/reformat_markdown.py
@@ -120,7 +120,7 @@ def _reformat_markdown_text(log_text: str, width: Number = 88) -> str:
             log_text = f"Lines {offset + 1}-{offset + content_length}"
         else:
             log_text = f"Line {offset + 1}"
-        logger.info(f"%s: %s", log_text, repr(formatter))
+        logger.info("%s: %s", log_text, repr(formatter))
         if section_type == MarkdownSectionEnum.BLANK_LINE:
             current_blank_lines.append(formatter)
         else:
@@ -154,8 +154,8 @@ def reformat_markdown_text(text: str, width: Number = 88) -> str:
     logger.setLevel(level)
     if new_new_text != new_text:
         raise ReformatInconsistentException(
-            f"Reformat of reformatted code results in different text. Please open a "
-            f"bug report or email jholland@duosecurity.com."
+            "Reformat of reformatted code results in different text. Please open a bug "
+            "report or email jholland@duosecurity.com."
         )
 
     return new_text

--- a/poetry.lock
+++ b/poetry.lock
@@ -98,25 +98,20 @@ version = "0.8"
 
 [[package]]
 category = "dev"
-description = "Discover and load entry points from installed packages."
-name = "entrypoints"
-optional = false
-python-versions = ">=2.7"
-version = "0.3"
-
-[[package]]
-category = "dev"
-description = "the modular source code checker: pep8, pyflakes and co"
+description = "the modular source code checker: pep8 pyflakes and co"
 name = "flake8"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "3.7.9"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+version = "3.8.4"
 
 [package.dependencies]
-entrypoints = ">=0.3.0,<0.4.0"
 mccabe = ">=0.6.0,<0.7.0"
-pycodestyle = ">=2.5.0,<2.6.0"
-pyflakes = ">=2.1.0,<2.2.0"
+pycodestyle = ">=2.6.0a1,<2.7.0"
+pyflakes = ">=2.2.0,<2.3.0"
+
+[package.dependencies.importlib-metadata]
+python = "<3.8"
+version = "*"
 
 [[package]]
 category = "dev"
@@ -240,7 +235,7 @@ description = "Python style guide checker"
 name = "pycodestyle"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.5.0"
+version = "2.6.0"
 
 [[package]]
 category = "dev"
@@ -248,7 +243,7 @@ description = "passive checker of Python programs"
 name = "pyflakes"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.1.1"
+version = "2.2.0"
 
 [[package]]
 category = "main"
@@ -373,7 +368,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-content-hash = "a224656cb1e02eb4cd55db6a70c7bbb4c93cfc907bb57402639aaac53363f38b"
+content-hash = "818d13804dac3a3b41c0561165835fccf53674512f881708aa77c4fe4017253d"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -460,13 +455,9 @@ dataclasses = [
     {file = "dataclasses-0.8-py3-none-any.whl", hash = "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf"},
     {file = "dataclasses-0.8.tar.gz", hash = "sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97"},
 ]
-entrypoints = [
-    {file = "entrypoints-0.3-py2.py3-none-any.whl", hash = "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19"},
-    {file = "entrypoints-0.3.tar.gz", hash = "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"},
-]
 flake8 = [
-    {file = "flake8-3.7.9-py2.py3-none-any.whl", hash = "sha256:49356e766643ad15072a789a20915d3c91dc89fd313ccd71802303fd67e4deca"},
-    {file = "flake8-3.7.9.tar.gz", hash = "sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb"},
+    {file = "flake8-3.8.4-py2.py3-none-any.whl", hash = "sha256:749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839"},
+    {file = "flake8-3.8.4.tar.gz", hash = "sha256:aadae8761ec651813c24be05c6f7b4680857ef6afaae4651a4eccaef97ce6c3b"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-3.4.0-py3-none-any.whl", hash = "sha256:ace61d5fc652dc280e7b6b4ff732a9c2d40db2c0f92bc6cb74e07b73d53a1771"},
@@ -529,12 +520,12 @@ py = [
     {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
 ]
 pycodestyle = [
-    {file = "pycodestyle-2.5.0-py2.py3-none-any.whl", hash = "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56"},
-    {file = "pycodestyle-2.5.0.tar.gz", hash = "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"},
+    {file = "pycodestyle-2.6.0-py2.py3-none-any.whl", hash = "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367"},
+    {file = "pycodestyle-2.6.0.tar.gz", hash = "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"},
 ]
 pyflakes = [
-    {file = "pyflakes-2.1.1-py2.py3-none-any.whl", hash = "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0"},
-    {file = "pyflakes-2.1.1.tar.gz", hash = "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"},
+    {file = "pyflakes-2.2.0-py2.py3-none-any.whl", hash = "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92"},
+    {file = "pyflakes-2.2.0.tar.gz", hash = "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"},
 ]
 pygments = [
     {file = "Pygments-2.7.4-py3-none-any.whl", hash = "sha256:bc9591213a8f0e0ca1a5e68a479b4887fdc3e75d0774e5c71c31920c427de435"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ rich = "*"
 [tool.poetry.dev-dependencies]
 black = "==19.10b0"
 commonmark = "*"
-flake8 = "3.7.9"
+flake8 = "*"
 isort = "*"
 mypy = "*"
 pytest = "*"


### PR DESCRIPTION
During the isort upgrade we had to hold back flake8. This resolves the new things it enforces.