### PR TITLE
Better align block quoting with the spec

### DIFF
--- a/markflow/_utils/_utils.py
+++ b/markflow/_utils/_utils.py
@@ -1,6 +1,11 @@
+import contextlib
+import logging
+from typing import Iterator
+
 __all__ = [
     "get_indent",
     "truncate_str",
+    "redirect_info_logs_to_debug",
 ]
 
 ELLIPSIS = "..."
@@ -19,3 +24,11 @@ def truncate_str(str_: str, length: int) -> str:
         truncation = max(0, length - len(ELLIPSIS))
         str_ = str_[:truncation] + ELLIPSIS
     return str_
+
+
+@contextlib.contextmanager
+def redirect_info_logs_to_debug() -> Iterator[None]:
+    old_info = logging.INFO
+    logging.INFO = logging.DEBUG
+    yield
+    logging.INFO = old_info

--- a/markflow/detectors/_lines.py
+++ b/markflow/detectors/_lines.py
@@ -60,8 +60,11 @@ def is_blank_line_line(line: str) -> bool:
     return not line.strip()
 
 
-def is_block_quote_line(line: str) -> bool:
-    """Evaluates whether a line is a block quote line
+def is_explicit_block_quote_line(line: str) -> bool:
+    """Evaluates whether a line is explicitly block quote line
+
+    The distinction here is that paragraph continuation lines can be part of a block
+    quote. This ensures that is what is desired.
 
     Example:
         ```
@@ -155,7 +158,7 @@ def is_paragraph_start_line(line: str) -> bool:
         is_indented_code_block_start_line,
         is_atx_heading_line,
         is_blank_line_line,
-        is_block_quote_line,
+        is_explicit_block_quote_line,
         is_fenced_code_block_start_line,
         is_list_start_line,
         is_table_start_line,

--- a/markflow/detectors/block_quote.py
+++ b/markflow/detectors/block_quote.py
@@ -1,33 +1,155 @@
+import re
 from typing import List, Tuple
 
-from ._lines import is_blank_line_line, is_block_quote_line, is_list_start_line
+from .._utils import redirect_info_logs_to_debug
+from ._lines import (
+    is_explicit_block_quote_line,
+    is_setext_underline,
+    is_thematic_break_line,
+)
+from .atx_heading import split_atx_heading
+from .blank_line import split_blank_line
+from .fenced_code_block import split_fenced_code_block
+from .list import split_list
+from .table import split_table
+from .thematic_break import split_thematic_break
+
+LEADING_QUOTE_MARKER = re.compile(r"^ {0,3}>")
 
 
-def block_quote_started(line: str, index: int, lines: List[str]) -> bool:
-    """DEPRECATED"""
-    return is_block_quote_line(line)
+def _is_paragraph_continuation_text(lines: List[str], line_offset: int = 0) -> bool:
+    """Indicates whether the first line of lines would continue a paragraph
+
+    This ensures that any valid interrupting section of a paragraph could not result in
+    a valid block instead.
+
+    We have a separate definition from the one used in paragraph detection to avoid
+    circular imports. This definition assumes the line doesn't start with '>'.
+
+    There is also a bit of a diversion from the spec here. According to the spec, the
+    following is a block-quoted paragraph:
+
+        > paragraph
+        title
+        =====
+
+    or:
+
+        > paragraph title =====
+
+    But, that looks odd, and the definition for paragraph continuation text could easily
+    be interpreted to consider that a paragraph and a title. So, we do the same here.
+    Given that MarkFlow output should not result in any paragraph continuation lines
+    after a block quote, there are no concerns around consistency. In the case of
+    trailing equals, e.g.
+
+        > paragraph
+        ===
+
+    the caller should detect this as a continuation line. But, if it is dashes, it
+    should be detected as a horizontal line.
+
+    There is an open issue on the ambiguity of paragraph continuation text here:
+    https://github.com/commonmark/commonmark-spec/issues/675
+
+    Args:
+        lines: The lines to evaluate.
+        line_offset (optional): The offset into the overall document we are at. This is
+            used for reporting errors in the original document.
+
+    Returns:
+        True if the first line would continue the paragraph. False otherwise.
+    """
+    from .setext_heading import split_setext_heading
+
+    for splitter in [
+        split_atx_heading,
+        split_blank_line,
+        split_fenced_code_block,
+        split_list,
+        split_setext_heading,
+        split_table,
+        split_thematic_break,
+    ]:
+        with redirect_info_logs_to_debug():
+            if splitter(lines, line_offset)[0]:
+                return False
+    if is_setext_underline(lines[0]):
+        return False
+    return True
 
 
-def block_quote_ended(line: str, index: int, lines: List[str]) -> bool:
-    """DEPRECATED"""
-    return is_blank_line_line(line) or is_list_start_line(line)
+def _block_quote_ends_with_paragraph(block_quote_lines: List[str]) -> bool:
+    # Avoid circular imports
+    from ..parser import MarkdownSectionEnum, parse_markdown
+
+    parsing_lines = []
+    for line in block_quote_lines:
+        parsing_lines.append(LEADING_QUOTE_MARKER.sub("", line))
+
+    with redirect_info_logs_to_debug():
+        ending_section_type, ending_section_content = parse_markdown(parsing_lines)[-1]
+
+    if ending_section_type == MarkdownSectionEnum.BLOCK_QUOTE:
+        return _block_quote_ends_with_paragraph(ending_section_content)
+    elif ending_section_type == MarkdownSectionEnum.PARAGRAPH:
+        return True
+    else:
+        return False
 
 
 def split_block_quote(
     lines: List[str], line_offset: int = 0
 ) -> Tuple[List[str], List[str]]:
-    block_quote = []
+    """Splits a block quote from the beginning of lines if one exists
+
+    We slightly differ from the spec when it comes to paragraph continuation lines.
+    While the spec detects the following as all a block quoted paragraph:
+
+        > code
+        TITLE
+        =====
+
+    we detect it as a block quote followed by a heading. In all other ways, we should
+    match the spec.
+
+    ToDo:
+        * This pattern could be applicable in paragraph detection and be easier to grok.
+          (Minus the parsing portion. That's not necessary.)
+
+    Returns:
+        A tuple of two values. The first is the block quote lines if a block quote was
+        found, otherwise it is an empty list. The second value is the remaining text.
+        (If lines does not start with a thematic break, it is the same as lines.)
+    """
+    block_quote: List[str] = []
     remaining_lines = lines
 
-    index = 0
-    if block_quote_started(lines[index], index, lines):
-        block_quote.append(lines[index])
-        for index, line in enumerate(lines[1:], start=index + 1):
-            if block_quote_ended(line, index, lines):
-                break
-            block_quote.append(line)
+    while remaining_lines:
+        if not is_explicit_block_quote_line(remaining_lines[0]):
+            break
+
+        while remaining_lines and is_explicit_block_quote_line(remaining_lines[0]):
+            block_quote += [remaining_lines[0]]
+            remaining_lines = remaining_lines[1:]
+
+        check_for_continuation = _block_quote_ends_with_paragraph(block_quote)
+
+        if check_for_continuation:
+            first_line = True
+            while remaining_lines and _is_paragraph_continuation_text(
+                remaining_lines, line_offset
+            ):
+                if first_line:
+                    first_line = False
+                    if is_setext_underline(
+                        remaining_lines[0]
+                    ) and not is_thematic_break_line(remaining_lines[0]):
+                        break
+                block_quote += [remaining_lines[0]]
+                remaining_lines = remaining_lines[1:]
+                line_offset += 1
         else:
-            index += 1
-    remaining_lines = lines[index:]
+            break
 
     return block_quote, remaining_lines

--- a/markflow/detectors/paragraph.py
+++ b/markflow/detectors/paragraph.py
@@ -10,11 +10,14 @@ from .table import split_table
 from .thematic_break import split_thematic_break
 
 
-def paragraph_continues(lines: List[str], line_offset: int = 0) -> bool:
+def _is_paragraph_continuation_text(lines: List[str], line_offset: int = 0) -> bool:
     """Indicates whether the first line of lines would continue a paragraph
 
     This ensures that any valid interrupting section of a paragraph could not result in
     a valid block instead.
+
+    We have a separate definition from the one used in block quote detection to avoid
+    circular imports. That one also gets to skip block quote checking.
 
     Args:
         lines: The lines to evaluate.
@@ -94,7 +97,9 @@ def split_paragraph_ignoring_setext(
         paragraph_lines.append(lines[0])
         tail_lines_generator = list_tail_generator(lines[1:])
         for tail in tail_lines_generator:
-            if paragraph_continues(tail, line_offset + len(paragraph_lines)):
+            if _is_paragraph_continuation_text(
+                tail, line_offset + len(paragraph_lines)
+            ):
                 paragraph_lines.append(tail[0])
                 # ToDo: This should be handled in `wrap` as a double space is always a
                 #  newline in any section type.

--- a/markflow/parser.py
+++ b/markflow/parser.py
@@ -1,0 +1,80 @@
+import logging
+from enum import Enum
+from typing import List, Tuple
+
+from .detectors import (
+    split_atx_heading,
+    split_blank_line,
+    split_block_quote,
+    split_fenced_code_block,
+    split_indented_code_block,
+    split_link_reference_definition,
+    split_list,
+    split_paragraph,
+    split_setext_heading,
+    split_table,
+    split_thematic_break,
+)
+from .typing import SplitFunc
+
+logger = logging.getLogger(__name__)
+
+
+class MarkdownSectionEnum(Enum):
+    INVALID = "Invalid"
+    ATX_HEADING = "ATX Heading"
+    BLANK_LINE = "Blank Line"
+    BLOCK_QUOTE = "Block Quote"
+    FENCED_CODE_BLOCK = "Fenced Code Block"
+    INDENTED_CODE_BLOCK = "Indented Code Block"
+    LINK_REFERENCE_DEFINITION = "Link Reference Definition"
+    LIST = "List"
+    PARAGRAPH = "Paragraph"
+    SETEXT_HEADING = "Setext Heading"
+    TABLE = "Table"
+    THEMATIC_BREAK = "Thematic Break"
+
+
+SPLITTERS: List[Tuple[MarkdownSectionEnum, SplitFunc]] = [
+    (MarkdownSectionEnum.ATX_HEADING, split_atx_heading),
+    (MarkdownSectionEnum.BLANK_LINE, split_blank_line),
+    (MarkdownSectionEnum.BLOCK_QUOTE, split_block_quote),
+    (MarkdownSectionEnum.FENCED_CODE_BLOCK, split_fenced_code_block),
+    (MarkdownSectionEnum.INDENTED_CODE_BLOCK, split_indented_code_block),
+    (MarkdownSectionEnum.LINK_REFERENCE_DEFINITION, split_link_reference_definition),
+    (MarkdownSectionEnum.LIST, split_list),
+    (MarkdownSectionEnum.PARAGRAPH, split_paragraph),
+    (MarkdownSectionEnum.SETEXT_HEADING, split_setext_heading),
+    (MarkdownSectionEnum.TABLE, split_table),
+    (MarkdownSectionEnum.THEMATIC_BREAK, split_thematic_break),
+]
+
+
+def parse_markdown(lines: List[str]) -> List[Tuple[MarkdownSectionEnum, List[str]]]:
+    sections: List[Tuple[MarkdownSectionEnum, List[str]]] = []
+    remaining_lines = lines
+    current_line = 1
+
+    while remaining_lines:
+        for section_type, splitter in SPLITTERS:
+            section_content, remaining_lines = splitter(remaining_lines)
+            if section_content:
+                content_length = len(section_content)
+                if content_length > 1:
+                    log_text = (
+                        f"Lines {current_line}-{current_line + content_length - 1}"
+                    )
+                else:
+                    log_text = f"Line {current_line}"
+                logger.debug(
+                    "%s: %s", log_text, section_type.value,
+                )
+                sections.append((section_type, section_content))
+                current_line += len(section_content)
+                break
+        else:
+            raise RuntimeError(
+                f"Could not determine section type on line {current_line}",
+            )
+
+    return sections

--- a/tests/files/0012_in_block_quotes.md
+++ b/tests/files/0012_in_block_quotes.md
@@ -21,3 +21,7 @@ More Quote
 > Surrounded By Block Quote Newlines
 > 
 > 
+
+> A lazy continuation
+in the middle of
+> normal block quote lines

--- a/tests/files/0012_out_block_quotes.md
+++ b/tests/files/0012_out_block_quotes.md
@@ -2,19 +2,21 @@ Block Quote Test
 ----------------
 
 Paragraph
->> Double Indented Quote
+> > Double Indented Quote
 >
 > Quote More Quote
 
 Paragraph
 
 > Quote More Quote
->>> Triple Indented Quote Triple Indented Quote
->>
->> Double Indented Quote
+> >> Triple Indented Quote Triple Indented Quote
+> >
+> >Double Indented Quote
 
->>
->>
+> >
+> >
 > Surrounded By Block Quote Newlines
 >
 >
+
+> A lazy continuation in the middle of normal block quote lines

--- a/tests/files/0023_in_setext_heading_close_to_block_quote.md
+++ b/tests/files/0023_in_setext_heading_close_to_block_quote.md
@@ -1,0 +1,3 @@
+> block quote
+Heading
+===

--- a/tests/files/0023_out_setext_heading_close_to_block_quote.md
+++ b/tests/files/0023_out_setext_heading_close_to_block_quote.md
@@ -1,0 +1,4 @@
+> block quote
+
+Heading
+=======

--- a/tests/test_block_quote.py
+++ b/tests/test_block_quote.py
@@ -22,12 +22,12 @@ class TestBlockQuote:
         )
         expected = textwrap.dedent(
             """\
-            >> Double Indented \\> Quote
+            > > Double Indented > Quote
             >
-            >>
+            > >
             > Quote \\> More Quote
-            >>> Triple Indented Quote Part of
-            >>> that Triple Indented Quote"""
+            > >> Triple Indented Quote Part of
+            > >> that Triple Indented Quote"""
         )
         block_quote = create_section(MarkdownBlockQuote, input_)
         assert block_quote.reformatted(width=35) == expected

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -15,6 +15,9 @@ logger = logging.getLogger(__name__)
 # TODO: File bug report for 0015
 PYCOMMONMARK_BUG_FILES = ["0015"]
 MARKFLOW_BUG_FILES = ["0016", "0017", "0018"]
+MARKFLOW_DIFFERENT_FILES = [
+    "0023"  # This file contains a block quote immediately followed by a setext heading
+]
 
 
 class FilePair:
@@ -101,5 +104,7 @@ class TestFiles:
             logger.info(
                 "Skipping render check due to a bug in the commonmark Python library."
             )
+        elif any(num in file_pair.input.name for num in MARKFLOW_DIFFERENT_FILES):
+            logger.info("Skipping render check as our parsing differs from the spec.")
         else:
             assert render(output_text) == render(input_text)


### PR DESCRIPTION
This change makes block quotes better match the spec. This required quite a bit of work as the first container block to migrate. We have to make several recursive calls to MarkFlow during parsing and rendering. In the former, we need to check and see if lines after explicit block quote lines should be included. For the latter, we render internal block quotes recursively.

It should be noted we diverge from the spec in one case that is commented. Further documentation will be added for other discrepancies. I am keeping a list and will add them all when I figure out the best way to explain them.