### PR TITLE
Bump version of MarkFlow to 0.2.1 now that we've released

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "markflow"
-version = "0.2.0"
+version = "0.2.1"
 description = "Make your Markdown Sparkle!"
 authors = ["Joshua Holland <jholland@duosecurity.com>"]
 


### PR DESCRIPTION
This will prevent clobbering of versions.